### PR TITLE
Better tw translations

### DIFF
--- a/tw/index.html
+++ b/tw/index.html
@@ -48,7 +48,7 @@
 		</tr>
 		<tr>
 			<td class="stars">&#x2605;&#x2605;&#x2605;&#x2605;</td>
-			<td>使用 <a href="http://en.wikipedia.org/wiki/Uniform_resource_identifier">固定網址</a> 來表式資料，使其它人可以連結到資料在資料網絡中的位置<a class="footnote" href="#addendum4" title="看看四顆星等級資料的成本和效益">4</a></td>
+			<td>使用 <a href="http://en.wikipedia.org/wiki/Uniform_resource_identifier">固定網址</a> 來表示資料，使其它人可以連結到資料在資料網絡中的位置<a class="footnote" href="#addendum4" title="看看四顆星等級資料的成本和效益">4</a></td>
 			<td><a href="gtd-4.html" title="四顆星等級的戈爾威郡氣溫資料">範例 ...</a></td>
 		</tr>
 		<tr>


### PR DESCRIPTION
Also, http://5stardata.info/tw/ is showing as garbled character in some browsers, because of the `Content-Type: text/html` header perhaps needs to be `Content-Type: text/html; charset=utf-8` instead — in `httpd.conf` one can say `AddDefaultCharset utf-8` to fix that.

I tried fixing this using HTML5 `meta charset` head element.
