### PR TITLE
Change “Excel” to “XLS” in 3* definition

### DIFF
--- a/en/_includes/by-example.md
+++ b/en/_includes/by-example.md
@@ -7,7 +7,7 @@ Below, we provide examples for each level of Tim's 5-star Open Data plan. The ex
   - make it available as structured data (e.g., Excel instead of image scan of a table)[2](#addendum2 "view costs and benefits of 2-star data")
   - [example &hellip;](examples/gtd-2.xls "2-star Galway temperature data")
 - &#x2605;&#x2605;&#x2605;
-  - make it available in a non-proprietary open format (e.g., CSV instead of Excel)[3](#addendum3 "view costs and benefits of 3-star data")
+  - make it available in a non-proprietary open format (e.g., CSV instead of XLS)[3](#addendum3 "view costs and benefits of 3-star data")
   - [example &hellip;](examples/gtd-3.csv "3-star Galway temperature data")
 - &#x2605;&#x2605;&#x2605;&#x2605;
   - use URIs to denote things, so that people can point at your stuff[4](#addendum4 "view costs and benefits of 4-star data")


### PR DESCRIPTION
While XLS is a proprietary format, XLSX isn’t. So this removes the
ambiguity.

Fixes #32.